### PR TITLE
Merge in matching_ports

### DIFF
--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -107,16 +107,16 @@ bool driver::add_tcp_connection(tcp_connection::role role, uint16_t port)
         return false;
     }
 }
-bool driver::add_udp_connection(uint16_t local_port, uint16_t remote_port)
+bool driver::add_udp_connection(uint16_t port)
 {
-    if(driver::m_udp_active.count(local_port) == 0)
+    if(driver::m_udp_active.count(port) == 0)
     {
         // Create the UDP connection.
-        udp_connection* new_udp = new udp_connection(driver::m_service, udp::endpoint(driver::m_local_ip, local_port), udp::endpoint(driver::m_remote_ip, remote_port));
+        udp_connection* new_udp = new udp_connection(driver::m_service, udp::endpoint(driver::m_local_ip, port));
         // Attach the rx callback.
         new_udp->attach_rx_callback(driver::m_callback_rx);
         // Add connection to map.
-        driver::m_udp_active.insert(std::make_pair(local_port, new_udp));
+        driver::m_udp_active.insert(std::make_pair(port, new_udp));
 
         return true;
     }

--- a/src/driver.h
+++ b/src/driver.h
@@ -49,11 +49,10 @@ public:
     bool add_tcp_connection(tcp_connection::role role, uint16_t port);
     ///
     /// \brief add_udp_connection Adds a UDP connection to the driver.
-    /// \param local_port The local port for the connection to communicate through.
-    /// \param remote_port The remote port for the connection to communicate through.
+    /// \param port The port that the connection shall communicate through.
     /// \return TRUE if the connection was added, otherwise FALSE.
     ///
-    bool add_udp_connection(uint16_t local_port, uint16_t remote_port);
+    bool add_udp_connection(uint16_t port);
     ///
     /// \brief remove_connection Removes an existing TCP/UDP connection.
     /// \param type The type of connection to remove (TCP or UDP).

--- a/src/ros_node.cpp
+++ b/src/ros_node.cpp
@@ -115,7 +115,7 @@ bool ros_node::add_tcp_connection(tcp_connection::role role, uint16_t port)
 }
 bool ros_node::add_udp_connection(uint16_t port)
 {
-    if(ros_node::m_driver->add_udp_connection(port, port))
+    if(ros_node::m_driver->add_udp_connection(port))
     {
         // Add UDP topic.
         ros_node::add_connection_topics(connection_type::UDP, port);

--- a/src/udp_connection.cpp
+++ b/src/udp_connection.cpp
@@ -3,13 +3,10 @@
 #include <boost/bind.hpp>
 
 // CONSTRUCTORS
-udp_connection::udp_connection(boost::asio::io_service& io_service, udp::endpoint local_endpoint, udp::endpoint remote_endpoint, uint32_t buffer_size)
+udp_connection::udp_connection(boost::asio::io_service& io_service, udp::endpoint local_endpoint, uint32_t buffer_size)
     // Initialize socket.
     :m_socket(io_service, local_endpoint)
 {
-    // Store remote endpoint.
-    udp_connection::m_remote_endpoint = remote_endpoint;
-
     // Dynamically allocate buffer.
     udp_connection::m_buffer_size = buffer_size;
     udp_connection::m_buffer = new uint8_t[buffer_size];
@@ -33,6 +30,7 @@ void udp_connection::tx(const uint8_t *data, uint32_t length)
 }
 void udp_connection::async_rx()
 {
+    // Start asynchronous receive, and store the source endpoint in m_remote_endpoint.
     udp_connection::m_socket.async_receive_from(boost::asio::buffer(udp_connection::m_buffer, udp_connection::m_buffer_size),
                                                 udp_connection::m_remote_endpoint,
                                                 boost::bind(&udp_connection::rx_callback, this, boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));

--- a/src/udp_connection.h
+++ b/src/udp_connection.h
@@ -21,10 +21,9 @@ public:
     /// \brief udp_connection Creates a new instance for the UDP connection.
     /// \param io_service The global IO Service to run the connection on.
     /// \param local_endpoint The local endpoint to bind to.
-    /// \param remote_endpoint The remote endpoint to communicate with.
     /// \param buffer_size The size of the RX buffer in bytes.
     ///
-    udp_connection(boost::asio::io_service& io_service, udp::endpoint local_endpoint, udp::endpoint remote_endpoint, uint32_t buffer_size=1024);
+    udp_connection(boost::asio::io_service& io_service, udp::endpoint local_endpoint, uint32_t buffer_size=1024);
     ~udp_connection();
 
     // METHODS
@@ -41,15 +40,17 @@ public:
     void tx(const uint8_t *data, uint32_t length);
 
 private:
-    // VARIABLES
+    // VARIABLES: SOCKET
     ///
     /// \brief m_socket The socket implementing the UDP connection.
     ///
     udp::socket m_socket;
     ///
-    /// \brief m_remote_endpoint The remote endpoint to communicate with.
+    /// \brief m_remote_endpoint Stores the remote endpoint information of received messages.
     ///
     udp::endpoint m_remote_endpoint;
+
+    // VARIABLES: RX BUFFER
     ///
     /// \brief m_buffer The internal buffer for storing received messages.
     ///
@@ -58,6 +59,8 @@ private:
     /// \brief m_buffer_size The size of the internal buffer in bytes.
     ///
     uint32_t m_buffer_size;
+
+    // VARIABLES: CALLBACKS
     ///
     /// \brief m_rx_callback The callback to raise when a message is received.
     ///


### PR DESCRIPTION
This forces all connections to communicate through the same port on both the local and remote machines.